### PR TITLE
update: embedded-hal dependency to v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 bitflags = "2.4"
-embedded-hal = "1.0.0-rc.3"
-embedded-hal-nb = "1.0.0-rc.3"
+embedded-hal = "1.0.0"
+embedded-hal-nb = "1.0.0"
 embedded-io = "0.6"
 heapless = "0.7"
 nb = "1.1"


### PR DESCRIPTION
The first stable release of `embedded-hal` is published!

Updates to the stable release.