### PR TITLE
pwm: add PWM module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,5 @@ pub mod gpio;
 pub mod i2c;
 pub mod interrupt;
 mod macros;
+pub mod pwm;
 pub mod uart;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1,0 +1,105 @@
+use embedded_hal::pwm::{ErrorType, SetDutyCycle};
+
+mod error;
+mod peripheral;
+
+pub use error::*;
+pub use peripheral::*;
+
+/// Represents the PWM PTC peripheral on JH71xx-based SoCs.
+pub struct Pwm<PWM: PwmPeripheral> {
+    periph: PWM,
+}
+
+impl<PWM: PwmPeripheral> Pwm<PWM> {
+    /// Creates a new [Pwm] from a PWM peripheral.
+    ///
+    /// Example:
+    ///
+    /// ```no_run
+    /// # use jh71xx_hal::{pac, pwm};
+    /// let dp = pac::Peripherals::take().unwrap();
+    /// let _pwm = pwm::Pwm::new(dp.PWM);
+    /// ```
+    pub fn new(mut periph: PWM) -> Self {
+        if periph.period() > MAX_PERIOD {
+            periph.set_period(MAX_PERIOD);
+        }
+        Self { periph }
+    }
+
+    /// Gets the period of the [Pwm] peripheral.
+    ///
+    /// Example:
+    ///
+    /// ```no_run
+    /// # use jh71xx_hal::{pac, pwm};
+    /// let dp = pac::Peripherals::take().unwrap();
+    /// let pwm = pwm::Pwm::new(dp.PWM);
+    /// let _period = pwm.period();
+    /// ```
+    pub fn period(&self) -> u16 {
+        (self.periph.period() & 0xffff) as u16
+    }
+
+    /// Sets the period of the [Pwm] peripheral.
+    ///
+    /// Example:
+    ///
+    /// ```no_run
+    /// # use jh71xx_hal::{pac, pwm};
+    /// let dp = pac::Peripherals::take().unwrap();
+    /// let mut pwm = pwm::Pwm::new(dp.PWM);
+    /// pwm.set_period(pwm::MAX_PERIOD as u16);
+    /// ```
+    pub fn set_period(&mut self, period: u16) {
+        self.periph.set_period(period as u32);
+    }
+
+    /// Gets whether the [Pwm] peripheral is enabled.
+    ///
+    /// Example:
+    ///
+    /// ```no_run
+    /// # use jh71xx_hal::{pac, pwm};
+    /// let dp = pac::Peripherals::take().unwrap();
+    /// let pwm = pwm::Pwm::new(dp.PWM);
+    /// if pwm.enabled() {
+    ///     // do interesting PWM stuff
+    /// }
+    /// ```
+    pub fn enabled(&self) -> bool {
+        self.periph.enabled()
+    }
+
+    /// Sets whether the PWM peripheral is enabled.
+    ///
+    /// Example:
+    ///
+    /// ```no_run
+    /// # use jh71xx_hal::{pac, pwm};
+    /// let dp = pac::Peripherals::take().unwrap();
+    /// let mut pwm = pwm::Pwm::new(dp.PWM);
+    /// if !pwm.enabled() {
+    ///     pwm.enable(true);
+    /// }
+    /// ```
+    pub fn enable(&mut self, val: bool) {
+        self.periph.enable(val);
+    }
+}
+
+impl<PWM: PwmPeripheral> ErrorType for Pwm<PWM> {
+    type Error = Error;
+}
+
+impl<PWM: PwmPeripheral> SetDutyCycle for Pwm<PWM> {
+    fn max_duty_cycle(&self) -> u16 {
+        (self.periph.period() & 0xffff) as u16
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<()> {
+        self.periph.set_duty(duty as u32);
+        Ok(())
+    }
+}

--- a/src/pwm/error.rs
+++ b/src/pwm/error.rs
@@ -1,0 +1,36 @@
+use embedded_hal::pwm::{Error as PwmError, ErrorKind};
+
+/// Convenience alias for the PWM module [`Result`](core::result::Result) type.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Represents the PWM module error type.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Error {
+    InvalidDutyCycle(u32),
+    InvalidPeriod(u32),
+    #[default]
+    Other,
+}
+
+impl From<&Error> for ErrorKind {
+    fn from(err: &Error) -> Self {
+        match err {
+            Error::InvalidDutyCycle(_cyc) => Self::Other,
+            Error::InvalidPeriod(_per) => Self::Other,
+            Error::Other => Self::Other,
+        }
+    }
+}
+
+impl From<Error> for ErrorKind {
+    fn from(err: Error) -> Self {
+        (&err).into()
+    }
+}
+
+impl PwmError for Error {
+    fn kind(&self) -> ErrorKind {
+        self.into()
+    }
+}

--- a/src/pwm/peripheral.rs
+++ b/src/pwm/peripheral.rs
@@ -1,0 +1,67 @@
+use pac::PWM;
+
+/// Max period length configurable by the HAL.
+pub const MAX_PERIOD: u32 = u16::MAX as u32;
+
+/// High-level functions to access low-level PWM PTC registers.
+pub trait PwmPeripheral {
+    /// Gets the PWM period value.
+    ///
+    /// This is the number of PWM clock cycles (APB by default).
+    fn period(&self) -> u32;
+    /// Sets the PWM period value.
+    ///
+    /// This is the number of PWM clock cycles (APB by default).
+    fn set_period(&mut self, val: u32);
+
+    /// Gets the PWM duty-cycle value.
+    fn duty(&self) -> u32;
+    /// Sets the PWM duty-cycle value.
+    ///
+    /// The maximum value is the PWM period value.
+    ///
+    /// If `val` exceeds the period value, duty-cycle will be set to the period.
+    fn set_duty(&mut self, val: u32);
+
+    /// Gets whether the PWM is enabled.
+    fn enabled(&self) -> bool;
+    /// Sets whether to enable the PWM.
+    fn enable(&mut self, val: bool);
+}
+
+macro_rules! impl_pwm_peripheral {
+    ($pwm:ident) => {
+        impl $crate::pwm::PwmPeripheral for $pwm {
+            fn period(&self) -> u32 {
+                self.lrc().read().lrc().bits()
+            }
+            fn set_period(&mut self, val: u32) {
+                self.lrc()
+                    .modify(|_, w| w.lrc().variant(core::cmp::min(val, MAX_PERIOD)));
+            }
+
+            fn duty(&self) -> u32 {
+                self.hrc().read().hrc().bits()
+            }
+            fn set_duty(&mut self, val: u32) {
+                let max = self.period();
+                self.hrc()
+                    .modify(|_, w| w.hrc().variant(core::cmp::min(val, max)));
+            }
+
+            fn enabled(&self) -> bool {
+                let r = self.ctrl().read();
+                r.en().bit_is_set() && r.oe().bit_is_set()
+            }
+            fn enable(&mut self, val: bool) {
+                self.ctrl().modify(|_, w| match val {
+                    false => w.en().clear_bit().oe().clear_bit(),
+                    true => w.en().set_bit().oe().set_bit(),
+                })
+            }
+        }
+    };
+}
+
+// FIXME: JH7110 TRM says the PWM is eight-channel, but there is only one entry in the DTS file...
+impl_pwm_peripheral!(PWM);


### PR DESCRIPTION
Adds the `embedded_hal::pwm::SetDutyCycle` implementation for JH71xx-based SoCs.